### PR TITLE
Honor Content-Type Overrides on Requests

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -18,6 +18,8 @@ const (
 	TypeDefault = "DEFAULT"
 	// TypeSmart is used to select the transportd HTTP client.
 	TypeSmart = "SMART"
+	// HeaderContentType Key for Content-Type HTTP Header.
+	HeaderContentType = "Content-Type"
 )
 
 // DefaultConfig contains all settings for the default Go HTTP client.
@@ -38,8 +40,12 @@ func (*DefaultComponent) Settings() *DefaultConfig {
 // New constructs a client from the given configuration
 func (*DefaultComponent) New(ctx context.Context, conf *DefaultConfig) (http.RoundTripper, error) {
 	return transport.NewHeader(
-		func(*http.Request) (string, string) {
-			return "Content-Type", conf.ContentType
+		func(request *http.Request) (string, string) {
+			contentType := request.Header.Get(HeaderContentType)
+			if contentType == "" {
+				contentType = conf.ContentType
+			}
+			return HeaderContentType, contentType
 		},
 	)(http.DefaultTransport), nil
 }

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -3,9 +3,12 @@ package httpclient
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/asecurityteam/settings"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,4 +96,54 @@ func TestHTTP(t *testing.T) {
 	})
 	_, err = New(context.Background(), src)
 	require.NotNil(t, err)
+}
+
+/*
+Given a default http client with a default Content-Type of application/json
+When a request is sent without a Content-Type header defined
+Then the request is sent with a Content-Type header set to application/json
+*/
+func TestDefaultContentType(t *testing.T) {
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "application/json", req.Header.Get(HeaderContentType))
+		_, err := rw.Write([]byte(`OK`))
+		if err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+	cmp := &DefaultComponent{}
+	conf := cmp.Settings()
+	tr, _ := cmp.New(context.Background(), conf)
+	client := server.Client()
+	client.Transport = tr
+	req, _ := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(`{"hello": "world"}`))
+	resp, _ := client.Do(req)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+/*
+Given a default http client with a default Content-Type of application/json
+When a request is sent with a Content-Type header set to application/jsonlines
+Then the request is sent with a Content-Type header set to application/jsonlines
+*/
+func TestDefaultContentTypeOverrideable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "application/jsonlines", req.Header.Get(HeaderContentType))
+		_, err := rw.Write([]byte(`OK`))
+		if err != nil {
+			return
+		}
+	}))
+	defer server.Close()
+	cmp := &DefaultComponent{}
+	conf := cmp.Settings()
+	tr, _ := cmp.New(context.Background(), conf)
+	client := server.Client()
+	client.Transport = tr
+	req, _ := http.NewRequest(http.MethodPost, server.URL, strings.NewReader(`{"hello": "world"}`))
+	req.Header.Set(HeaderContentType, "application/jsonlines")
+	resp, _ := client.Do(req)
+	assert.Equal(t, 200, resp.StatusCode)
 }


### PR DESCRIPTION
When using a default HTTP client and a Content-Type header is present on the request, use that Content-Type value. Otherwise, use the default Content-Type from the settings.